### PR TITLE
Conserta erro no avaliador

### DIFF
--- a/src/components/Categories.jsx
+++ b/src/components/Categories.jsx
@@ -35,14 +35,6 @@ class Categories extends React.Component {
             {item.name}
           </button>
         ))}
-        <button
-          type="button"
-          onClick={ handleCategory }
-          data-testid="category"
-          id=""
-        >
-          Limpar
-        </button>
       </>
     );
   }


### PR DESCRIPTION
Erro causado por botão com a categoria "limpar"