### PR TITLE
Requisito 13 v01

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,19 +5,55 @@ import './App.css';
 import Home from './pages/Home';
 import ShoppingCart from './pages/ShoppingCart';
 import ProductDetails from './pages/ProductDetails';
+import CartSizeContext from './services/context';
 
-function App() {
-  return (
-    <Router>
-      <main className="App">
-        <Switch>
-          <Route path="/details/:id" component={ ProductDetails } />
-          <Route path="/pages/shoppingcart" component={ ShoppingCart } />
-          <Route exact path="/" component={ Home } />
-        </Switch>
-      </main>
-    </Router>
-  );
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const cartSize = localStorage.cartItems ? this.calcSize(localStorage.cartItems) : 0;
+
+    this.state = {
+      cartSize,
+    };
+
+    this.updateCartSize = this.updateCartSize.bind(this);
+  }
+
+  calcSize(storage) {
+    return JSON.parse(storage).reduce((acc, { quantity }) => acc + quantity, 0);
+  }
+
+  updateCartSize() {
+    this.setState({
+      cartSize: this.calcSize(localStorage.cartItems),
+    });
+  }
+
+  render() {
+    const { cartSize } = this.state;
+    return (
+      <CartSizeContext.Provider value={ this.updateCartSize }>
+        <Router>
+          <main className="App">
+            <Switch>
+              <Route
+                path="/details/:id"
+                render={ (props) => (
+                  <ProductDetails { ...props } cartSize={ cartSize } />) }
+              />
+              <Route path="/pages/shoppingcart" component={ ShoppingCart } />
+              <Route
+                exact
+                path="/"
+                render={ (props) => <Home { ...props } cartSize={ cartSize } /> }
+              />
+            </Switch>
+          </main>
+        </Router>
+      </CartSizeContext.Provider>
+    );
+  }
 }
 
 export default App;

--- a/src/components/AddProduct.js
+++ b/src/components/AddProduct.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { updateStorageItem } from '../services/storageFuncs';
+import CartSizeContext from '../services/context';
 
 class AddProduct extends Component {
   constructor(props) {
@@ -12,12 +13,14 @@ class AddProduct extends Component {
 
   onClick() {
     const { item } = this.props;
+    const updateCartSize = this.context;
     if (localStorage.cartItems) {
       updateStorageItem(item);
     } else {
       const quantifiedItem = { ...item, quantity: 1 };
       localStorage.cartItems = JSON.stringify([quantifiedItem]);
     }
+    updateCartSize();
   }
 
   render() {
@@ -33,6 +36,8 @@ class AddProduct extends Component {
     );
   }
 }
+
+AddProduct.contextType = CartSizeContext;
 
 AddProduct.propTypes = {
   item: PropTypes.shape({

--- a/src/components/CartItem.js
+++ b/src/components/CartItem.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { updateStorageQuantity } from '../services/storageFuncs';
+import CartSizeContext from '../services/context';
 
 class CartItem extends Component {
   constructor(props) {
@@ -35,8 +36,10 @@ class CartItem extends Component {
   updateAll() {
     const { item: { title }, handleChange } = this.props;
     const { quantity } = this.state;
+    const updateCartSize = this.context;
     updateStorageQuantity(title, quantity);
     handleChange();
+    updateCartSize();
   }
 
   render() {
@@ -70,6 +73,8 @@ class CartItem extends Component {
     );
   }
 }
+
+CartItem.contextType = CartSizeContext;
 
 CartItem.propTypes = {
   item: PropTypes.shape({

--- a/src/components/CartQuantifier.js
+++ b/src/components/CartQuantifier.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class CartQuantifier extends Component {
+  render() {
+    const { size } = this.props;
+    return (
+      <div data-testid="shopping-cart-size">
+        { size }
+      </div>
+    );
+  }
+}
+
+CartQuantifier.propTypes = {
+  size: PropTypes.number.isRequired,
+};
+
+export default CartQuantifier;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
-// import PropTypes from 'prop-types';
-
+import CartQuantifier from '../components/CartQuantifier';
 import FilterCategories from '../components/FilterCategories';
 import ProductList from '../components/ProductList';
 import QueryInput from '../components/QueryInput';
@@ -50,12 +50,14 @@ class Home extends Component {
 
   render() {
     const { items } = this.state;
+    const { cartSize } = this.props;
 
     return (
       <>
         <header>
           <Link to="/pages/shoppingcart" data-testid="shopping-cart-button">
             Carrinho
+            <CartQuantifier size={ cartSize } />
           </Link>
           <p data-testid="home-initial-message">
             Digite algum termo de pesquisa ou escolha uma categoria.
@@ -72,7 +74,7 @@ class Home extends Component {
 }
 
 Home.propTypes = {
-
+  cartSize: PropTypes.number.isRequired,
 };
 
 export default Home;

--- a/src/pages/ProductDetails.js
+++ b/src/pages/ProductDetails.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import AddProduct from '../components/AddProduct';
 import Loading from '../components/Loading';
+import CartQuantifier from '../components/CartQuantifier';
 
 class ProductDetails extends React.Component {
   constructor(props) {
@@ -32,20 +33,25 @@ class ProductDetails extends React.Component {
 
   render() {
     const { productInfo, loading } = this.state;
-    return loading ? <Loading /> : (
+    const { cartSize } = this.props;
+
+    return (
       <>
         <header>
           <Link to="/pages/shoppingcart" data-testid="shopping-cart-button">
             Carrinho
+            <CartQuantifier size={ cartSize } />
           </Link>
         </header>
-        <section>
-          <h1 data-testid="product-detail-name">{ productInfo.title }</h1>
-          <img src={ productInfo.thumbnail } alt="Imagem do produto" />
-          <p>{ `R$ ${productInfo.price.toFixed(2)}` }</p>
-          <AddProduct item={ productInfo } testid="product-detail-add-to-cart" />
-          <h3>Especificacoes Tecnicas</h3>
-        </section>
+        { loading ? <Loading /> : (
+          <section>
+            <h1 data-testid="product-detail-name">{ productInfo.title }</h1>
+            <img src={ productInfo.thumbnail } alt="Imagem do produto" />
+            <p>{ `R$ ${productInfo.price.toFixed(2)}` }</p>
+            <AddProduct item={ productInfo } testid="product-detail-add-to-cart" />
+            <h3>Especificacoes Tecnicas</h3>
+          </section>
+        ) }
       </>
     );
   }
@@ -57,6 +63,7 @@ ProductDetails.propTypes = {
       id: PropTypes.string,
     }),
   }).isRequired,
+  cartSize: PropTypes.number.isRequired,
 };
 
 export default ProductDetails;

--- a/src/services/context.js
+++ b/src/services/context.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const CartSizeContext = React.createContext();
+
+export default CartSizeContext;


### PR DESCRIPTION
**13. Mostre junto ao ícone do carrinho a quantidade de produtos dentro dele, em todas as telas em que ele aparece**

**Observações técnicas**
A partir de uma pesquisa com usuários e concorrentes, identificamos que existe a necessidade de uma visualização da quantidade de produtos do carrinho de uma forma dinâmica e acessível.

- [ ] Adicione o atributo data-testid com o valor shopping-cart-size no elemento que contém a quantidade de produtos presente na lista.
- [ ] A quantidade a ser exibida é o número total de itens, ou seja, se a pessoa adiciona o produto1 5 vezes e o produto2 2 vezes, o valor a ser exibido é 7.
- [ ] Esse elemnento deve ser visível da página de listagem de produtos e da página de detalhes de produto.